### PR TITLE
feat: create browser context and page per test

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,5 +3,6 @@
 !types/
 !index.js
 !setup.js
+!setupAfterEnv.js
 !teardown.js
 !jest-preset.json

--- a/e2e/stub.test.ts
+++ b/e2e/stub.test.ts
@@ -3,7 +3,11 @@ import path from 'path'
 describe('Example HTML file', () => {
   it('should detect the heading "Example" on page', async () => {
     await page.goto(`file:${path.join(__dirname, 'example.html')}`)
+    expect(page.url()).not.toBe('about:blank')
     const browser = await page.$eval('h1', (el) => el.textContent)
     expect(browser).toBe('Example')
+  })
+  it('should not reuse the page', async () => {
+    expect(page.url()).toBe('about:blank')
   })
 })

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -1,5 +1,6 @@
 {
   "globalSetup": "jest-playwright-preset/setup.js",
   "globalTeardown": "jest-playwright-preset/teardown.js",
-  "testEnvironment": "jest-playwright-preset"
+  "testEnvironment": "jest-playwright-preset",
+  "setupFilesAfterEnv": ["jest-playwright-preset/setupAfterEnv.js"]
 }

--- a/jest.config.e2e.js
+++ b/jest.config.e2e.js
@@ -3,4 +3,5 @@ module.exports = {
   testEnvironment: './lib/PlaywrightEnvironment.js',
   testPathIgnorePatterns: ['/node_modules/', 'lib'],
   testMatch: ['**/e2e/**/*.test.ts'],
+  setupFilesAfterEnv: ['./setupAfterEnv.js'],
 }

--- a/setupAfterEnv.js
+++ b/setupAfterEnv.js
@@ -1,0 +1,19 @@
+beforeEach(async () => {
+  const handleError = (error) => {
+    process.emit('uncaughtException', error)
+  }
+
+  global.context = await global.browser.newContext(
+    global.jestPlaywright.__contextOptions,
+  )
+  global.page = await global.context.newPage()
+  global.page.on('pageerror', handleError)
+})
+
+afterEach(async () => {
+  if (global.context) {
+    await global.context.close()
+    delete global.context
+    delete global.page
+  }
+})

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -12,10 +12,6 @@ import {
 import { Config, CHROMIUM, GenericBrowser } from './constants'
 import playwright, { Browser } from 'playwright-core'
 
-const handleError = (error: Error): void => {
-  process.emit('uncaughtException', error)
-}
-
 const KEYS = {
   CONTROL_C: '\u0003',
   CONTROL_D: '\u0004',
@@ -131,10 +127,8 @@ class PlaywrightEnvironment extends NodeEnvironment {
       contextOptions = { viewport, userAgent, ...contextOptions }
     }
     this.global.browser = await getBrowserPerProcess(playwrightInstance, config)
-    this.global.context = await this.global.browser.newContext(contextOptions)
-    this.global.page = await this.global.context.newPage()
-    this.global.page.on('pageerror', handleError)
     this.global.jestPlaywright = {
+      __contextOptions: contextOptions,
       debug: async (): Promise<void> => {
         // Run a debugger (in case Playwright has been launched with `{ devtools: true }`)
         await this.global.page.evaluate(() => {
@@ -180,10 +174,6 @@ class PlaywrightEnvironment extends NodeEnvironment {
     await super.teardown()
     if (!jestConfig.watch && !jestConfig.watchAll && teardownServer) {
       await teardownServer()
-    }
-    if (this.global.page) {
-      this.global.page.removeListener('pageerror', handleError)
-      await this.global.page.close()
     }
     startBrowserCloseWatchdog()
   }


### PR DESCRIPTION
What do you think about this major breaking change?

Pros:
- Ensures isolation between tests and therefore guards against subtle inter-dependencies between tests making everything flaky over time.

Cons:
- Breaking change. Existing test suites which rely on a single page will break.
- Large test suites that used to do a lot of small tests will be slower, because they have to create page multiple times. With context per test, the better strategy would be to include multiple checks  into a single test, when they are related to a single scenario.

We can also add a helper for new context (encapsulating context options), or expose context options, to allow users to manually reuse page between tests if they really need to:

```js
let context;
let page;

beforeAll(async () => {
  // exposing newContext
  context = await global.newContext();
  // or exposing contextOptions
  context = await global.browser.newContext(global.contextOptions);
  page = await context.newPage();
});

afterAll(async () => {
  await context.close();
});
```

Note: I am not sure this is a best way to integrate "context per test" with jest ecosystem, any advice is appreciated.
