### PR TITLE
Set timeouts underhood

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-ignore */
 import NodeEnvironment from 'jest-environment-node'
 import { Config as JestConfig } from '@jest/types'
+import { Event, State } from 'jest-circus'
 import {
   getBrowserType,
   getDeviceType,
@@ -174,6 +175,18 @@ class PlaywrightEnvironment extends NodeEnvironment {
           stdin.on('data', onKeyPress)
         })
       },
+    }
+  }
+
+  async handleTestEvent(event: Event, state: State) {
+    // Hack to set testTimeout for jestPlaywright debugging
+    if (
+      event.name === 'add_test' &&
+      event.fn &&
+      event.fn.toString().includes('jestPlaywright.debug()')
+    ) {
+      // Set timeout to 4 days
+      state.testTimeout = 345600000
     }
   }
 

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -178,7 +178,7 @@ class PlaywrightEnvironment extends NodeEnvironment {
     }
   }
 
-  async handleTestEvent(event: Event, state: State) {
+  async handleTestEvent(event: Event, state: State): Promise<void> {
     // Hack to set testTimeout for jestPlaywright debugging
     if (
       event.name === 'add_test' &&
@@ -186,7 +186,7 @@ class PlaywrightEnvironment extends NodeEnvironment {
       event.fn.toString().includes('jestPlaywright.debug()')
     ) {
       // Set timeout to 4 days
-      state.testTimeout = 345600000
+      state.testTimeout = 4 * 24 * 60 * 60 * 1000
     }
   }
 

--- a/src/PlaywrightRunner.ts
+++ b/src/PlaywrightRunner.ts
@@ -66,7 +66,10 @@ class PlaywrightRunner extends JestRunner {
     globalConfig: JestConfig.GlobalConfig,
     context: TestRunnerContext,
   ) {
-    super(globalConfig, context)
+    const config = { ...globalConfig }
+    // Set default timeout to 15s
+    config.testTimeout = config.testTimeout || 15000
+    super(config, context)
   }
 
   async runTests(


### PR DESCRIPTION
Using **jest-circus** to set timeouts underhood. This is another kind of hacky solution. I'm not sure about setting it inside **handleTestEvent** for `jestPlaywright.debug`, cause check whole tests have this function can be slow. But I suppose increasing it inside runner can be a good idea 