### PR TITLE
Fix devices error with playwright-core

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     'import/no-dynamic-require': 'off',
     'import/no-unresolved': 'off',
     'prettier/prettier': 'error',
+    '@typescript-eslint/ban-ts-ignore': 'off',
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -3,8 +3,6 @@
 import type { Config as JestConfig } from '@jest/types'
 import type { Event, State } from 'jest-circus'
 import type { Browser } from 'playwright-core'
-// @ts-ignore
-import { DeviceDescriptors } from 'playwright-core/lib/deviceDescriptors'
 import type { Config, GenericBrowser, BrowserType } from './types'
 import { CHROMIUM, IMPORT_KIND_PLAYWRIGHT } from './constants'
 import {
@@ -78,14 +76,14 @@ export const getPlaywrightEnv = (basicEnv = 'node') => {
       }
       //@ts-ignore
       const device = getDeviceType(this._config.device)
-      const playwrightInstance = await getPlaywrightInstance(
+      const { instance: playwrightInstance, devices } = getPlaywrightInstance(
         playwrightPackage,
         browserType,
       )
       let contextOptions = context
 
       if (device) {
-        const { viewport, userAgent } = DeviceDescriptors[device]
+        const { viewport, userAgent } = devices[device]
         contextOptions = { viewport, userAgent, ...contextOptions }
       }
       this.global.browserName = browserType

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -3,7 +3,8 @@
 import type { Config as JestConfig } from '@jest/types'
 import type { Event, State } from 'jest-circus'
 import type { Browser } from 'playwright-core'
-import playwright from 'playwright-core'
+// @ts-ignore
+import { DeviceDescriptors } from 'playwright-core/lib/deviceDescriptors'
 import type { Config, GenericBrowser, BrowserType } from './types'
 import { CHROMIUM, IMPORT_KIND_PLAYWRIGHT } from './constants'
 import {
@@ -84,7 +85,7 @@ export const getPlaywrightEnv = (basicEnv = 'node') => {
       let contextOptions = context
 
       if (device) {
-        const { viewport, userAgent } = playwright.devices[device]
+        const { viewport, userAgent } = DeviceDescriptors[device]
         contextOptions = { viewport, userAgent, ...contextOptions }
       }
       this.global.browserName = browserType

--- a/src/PlaywrightRunner.ts
+++ b/src/PlaywrightRunner.ts
@@ -39,7 +39,7 @@ const getBrowserTest = (
         displayName: {
           name: displayName
             ? `${playwrightDisplayName} ${
-                (displayName as { name: string }).name
+                typeof displayName === 'string' ? displayName : displayName.name
               }`
             : playwrightDisplayName,
           color: 'yellow',

--- a/src/PlaywrightRunner.ts
+++ b/src/PlaywrightRunner.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import JestRunner from 'jest-runner'
-import playwright from 'playwright-core'
+import { DeviceDescriptors } from 'playwright-core/lib/deviceDescriptors'
 import type {
   Test,
   TestRunnerContext,
@@ -55,7 +55,7 @@ const getTests = (tests: Test[]): Promise<Test[]> => {
         checkBrowserEnv(browser)
         return devices.length
           ? devices.flatMap((device) => {
-              const availableDevices = Object.keys(playwright.devices)
+              const availableDevices = Object.keys(DeviceDescriptors)
               checkDeviceEnv(device, availableDevices)
               return getBrowserTest(test, browser, device)
             })

--- a/src/PlaywrightRunner.ts
+++ b/src/PlaywrightRunner.ts
@@ -1,6 +1,4 @@
-// @ts-nocheck
 import JestRunner from 'jest-runner'
-import { DeviceDescriptors } from 'playwright-core/lib/deviceDescriptors'
 import type {
   Test,
   TestRunnerContext,
@@ -17,6 +15,8 @@ import {
   checkDeviceEnv,
   getDisplayName,
   readConfig,
+  getPlaywrightInstance,
+  readPackage,
 } from './utils'
 import { DEFAULT_TEST_PLAYWRIGHT_TIMEOUT } from './constants'
 
@@ -33,11 +33,14 @@ const getBrowserTest = (
       ...test.context,
       config: {
         ...test.context.config,
+        // @ts-ignore
         browserName: browser,
         device,
         displayName: {
           name: displayName
-            ? `${playwrightDisplayName} ${displayName.name}`
+            ? `${playwrightDisplayName} ${
+                (displayName as { name: string }).name
+              }`
             : playwrightDisplayName,
           color: 'yellow',
         },
@@ -46,17 +49,22 @@ const getBrowserTest = (
   }
 }
 
-const getTests = (tests: Test[]): Promise<Test[]> => {
-  return Promise.all(
+const getTests = async (tests: Test[]): Promise<Test[]> => {
+  const playwrightPackage = await readPackage()
+  return await Promise.all(
     tests.map(async (test) => {
       const { rootDir } = test.context.config
       const { browsers, devices } = await readConfig(rootDir)
       return browsers.flatMap((browser) => {
         checkBrowserEnv(browser)
-        return devices.length
+        const { devices: availableDevices } = getPlaywrightInstance(
+          playwrightPackage,
+          browser,
+        )
+        return devices
           ? devices.flatMap((device) => {
-              const availableDevices = Object.keys(DeviceDescriptors)
-              checkDeviceEnv(device, availableDevices)
+              const availableDeviceNames = Object.keys(availableDevices)
+              checkDeviceEnv(device, availableDeviceNames)
               return getBrowserTest(test, browser, device)
             })
           : getBrowserTest(test, browser, null)
@@ -87,14 +95,14 @@ class PlaywrightRunner extends JestRunner {
     const browserTests = await getTests(tests)
 
     return await (options.serial
-      ? this._createInBandTestRun(
+      ? this['_createInBandTestRun'](
           browserTests,
           watcher,
           onStart,
           onResult,
           onFailure,
         )
-      : this._createParallelTestRun(
+      : this['_createParallelTestRun'](
           browserTests,
           watcher,
           onStart,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import type {
   FirefoxBrowser,
   BrowserType as PlaywrightBrowserType,
   BrowserTypeConnectOptions,
+  DeviceDescriptor,
 } from 'playwright-core'
 import type { JestDevServerOptions } from 'jest-dev-server'
 import { CHROMIUM, FIREFOX, IMPORT_KIND_PLAYWRIGHT, WEBKIT } from './constants'
@@ -21,13 +22,20 @@ export type SelectorType = {
   name: string
 }
 
+type Devices = { [name: string]: DeviceDescriptor }
+
+export interface Playwright {
+  instance: GenericBrowser
+  devices: Devices
+}
+
 export type PlaywrightRequireType = BrowserType | typeof IMPORT_KIND_PLAYWRIGHT
 
 export interface Config {
   launchBrowserApp?: BrowserTypeLaunchOptions
   context?: BrowserNewContextOptions
   exitOnPageError: boolean
-  browsers?: BrowserType[]
+  browsers: BrowserType[]
   devices?: string[]
   server?: JestDevServerOptions
   selectors?: SelectorType[]

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -232,7 +232,7 @@ describe('getPlaywrightInstance', () => {
       firefox: 'firefox',
     }))
 
-    const instance = await getPlaywrightInstance('playwright', 'firefox')
+    const { instance } = getPlaywrightInstance('playwright', 'firefox')
     expect(instance).toEqual('firefox')
   })
 
@@ -243,7 +243,7 @@ describe('getPlaywrightInstance', () => {
       chromium: 'chromium',
     }))
 
-    const instance = await getPlaywrightInstance('chromium', 'chromium')
+    const { instance } = getPlaywrightInstance('chromium', 'chromium')
     expect(instance).toEqual('chromium')
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import type {
   BrowserType,
   Config,
   PlaywrightRequireType,
-  GenericBrowser,
+  Playwright,
 } from './types'
 import {
   CHROMIUM,
@@ -87,14 +87,22 @@ export const readPackage = async (): Promise<PlaywrightRequireType> => {
   return playwright
 }
 
-export const getPlaywrightInstance = async (
+export const getPlaywrightInstance = (
   playwrightPackage: PlaywrightRequireType,
-  browserType: BrowserType,
-): Promise<GenericBrowser> => {
-  if (playwrightPackage === IMPORT_KIND_PLAYWRIGHT) {
-    return require('playwright')[browserType]
+  browserName: BrowserType,
+): Playwright => {
+  const buildPlaywrightStructure = (importName: string): Playwright => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pw = require(importName)
+    return {
+      instance: pw[browserName],
+      devices: pw['devices'],
+    }
   }
-  return require(`playwright-${playwrightPackage}`)[playwrightPackage]
+  if (playwrightPackage === IMPORT_KIND_PLAYWRIGHT) {
+    return buildPlaywrightStructure('playwright')
+  }
+  return buildPlaywrightStructure(`playwright-${playwrightPackage}`)
 }
 
 export const readConfig = async (


### PR DESCRIPTION
Close #125 

I'm not sure if it's really nice solution, cause it's make TS unhappy. Some research on it.
With current **playwright** version there is `index.js` file in **playwright-core** package
<img width="279" alt="Снимок экрана 2020-05-21 в 13 01 10" src="https://user-images.githubusercontent.com/22371328/82547917-269b4900-9b63-11ea-9819-a2b238937192.png">
But with **next** version it’s missed
<img width="246" alt="Снимок экрана 2020-05-21 в 13 05 54" src="https://user-images.githubusercontent.com/22371328/82548313-d1136c00-9b63-11ea-85e0-a8f364bf986b.png">

@mxschmitt maybe you got some information about it. Cause maybe it's a bug. 