### PR TITLE
fix: checkDependencies if no package was found

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -31,7 +31,7 @@ const getBrowserPerProcess = async (
   // https://github.com/mmarkelov/jest-playwright/issues/42#issuecomment-589170220
   if (browserType !== CHROMIUM && launchBrowserApp && launchBrowserApp.args) {
     launchBrowserApp.args = launchBrowserApp.args.filter(
-      (item) => item !== '--no-sandbox',
+      (item: string) => item !== '--no-sandbox',
     )
   }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -153,6 +153,16 @@ describe('checkDeviceEnv', () => {
 })
 
 describe('checkDependencies', () => {
+  it('should return null for empty dependencies', () => {
+    const dep = checkDependencies({})
+    expect(dep).toBe(null)
+  })
+
+  it('should return null for dependencies without playwright packages', () => {
+    const dep = checkDependencies({ test: '0.0.1' })
+    expect(dep).toBe(null)
+  })
+
   it('should return right package object for single package', () => {
     const dep = checkDependencies({ 'playwright-chromium': '*' })
     expect(dep).toStrictEqual({ [CHROMIUM]: CHROMIUM })

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -218,6 +218,24 @@ describe('readPackage', () => {
     const playwright = await readPackage()
     expect(playwright).toStrictEqual({ [FIREFOX]: FIREFOX })
   })
+  it('should return playwright-firefox when it is defined and empty dependencies are persistent', async () => {
+    ;((fs.exists as unknown) as jest.Mock).mockImplementationOnce(
+      (_, cb: (exists: boolean) => void) => cb(true),
+    )
+    jest.mock(
+      path.join(__dirname, '..', 'package.json'),
+      () => ({
+        dependencies: {},
+        devDependencies: {
+          'playwright-firefox': '*',
+        },
+      }),
+      { virtual: true },
+    )
+
+    const playwright = await readPackage()
+    expect(playwright).toStrictEqual({ [FIREFOX]: FIREFOX })
+  })
 })
 
 describe('getPlaywrightInstance', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export const checkDependencies = (
   dependencies: Record<string, string>,
 ): Packages | typeof IMPORT_KIND_PLAYWRIGHT | null => {
   const packages: Packages = {}
-  if (!dependencies) return null
+  if (!dependencies || Object.keys(dependencies).length === 0) return null
   if (dependencies.playwright) return IMPORT_KIND_PLAYWRIGHT
   if (dependencies[`playwright-${CHROMIUM}`]) {
     packages[CHROMIUM] = CHROMIUM
@@ -88,7 +88,7 @@ export const readPackage = async (): Promise<
   const playwright =
     checkDependencies(packageConfig.dependencies) ||
     checkDependencies(packageConfig.devDependencies)
-  if (!playwright || !Object.keys(playwright).length) {
+  if (playwright === null) {
     throw new Error('None of playwright packages was not found in dependencies')
   }
   return playwright

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,9 @@ export const checkDependencies = (
   if (dependencies[`playwright-${WEBKIT}`]) {
     packages[WEBKIT] = WEBKIT
   }
+  if (Object.keys(packages).length === 0) {
+    return null
+  }
   return packages
 }
 


### PR DESCRIPTION
In the previous release there was a bug, that caused `checkDependenices()` to return an empty object if no playwright package was found. This resulted to a truthy if condition here:

https://github.com/playwright-community/jest-playwright/blob/6e0d933c92db88b59e2ba4f6d16f09a4e7dca348/src/utils.ts#L78-L95

Which cause the following error:

```
None of playwright packages was not found in dependencies
``` 