### PR TITLE
breaking: standardise options

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ describe('What is my browser', () => {
 
 You can specify a `jest-playwright.config.js` at the root of the project or define a custom path using the `JEST_PLAYWRIGHT_CONFIG` environment variable. It should export a config object.
 
-- `launchBrowserApp` <[object]> [All Playwright launch options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsertypelaunchoptions) can be specified in config. Since it is JavaScript, you can use all stuff you need, including environment.
-- `connectBrowserApp` <[object]> [All Playwright connect options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsertypeconnectoptions) can be specified in config.
-- `context` <[object]> [All Playwright context options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsernewcontextoptions) can be specified in config.
+- `launchOptions` <[object]> [All Playwright launch options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsertypelaunchoptions) can be specified in config. Since it is JavaScript, you can use all stuff you need, including environment.
+- `connectOptions` <[object]> [All Playwright connect options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsertypeconnectoptions) can be specified in config.
+- `contextOptions` <[object]> [All Playwright context options](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsernewcontextoptions) can be specified in config.
 - `browsers` <[string[]]>. Define [browsers](https://github.com/microsoft/playwright/blob/master/docs/api.md#class-browsertype) to run tests in.
   - `chromium` Each test runs Chromium (default).
   - `firefox` Each test runs Firefox.
@@ -136,7 +136,7 @@ To use it, specify a server section in your `jest-playwright.config.js`.
 ```js
 // jest-playwright.config.js
 module.exports = {
-  server: {
+  serverOptions: {
     command: 'node server.js',
     port: 4444,
   },

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -31,18 +31,18 @@ const getBrowserPerProcess = async (
   browserType: BrowserType,
   config: Config,
 ): Promise<Browser> => {
-  const { launchBrowserApp, connectBrowserApp } = config
+  const { launchOptions, connectOptions } = config
   // https://github.com/mmarkelov/jest-playwright/issues/42#issuecomment-589170220
-  if (browserType !== CHROMIUM && launchBrowserApp && launchBrowserApp.args) {
-    launchBrowserApp.args = launchBrowserApp.args.filter(
+  if (browserType !== CHROMIUM && launchOptions && launchOptions.args) {
+    launchOptions.args = launchOptions.args.filter(
       (item: string) => item !== '--no-sandbox',
     )
   }
 
-  if (connectBrowserApp) {
-    return await playwrightInstance.connect(connectBrowserApp)
+  if (connectOptions) {
+    return await playwrightInstance.connect(connectOptions)
   } else {
-    return await playwrightInstance.launch(launchBrowserApp)
+    return await playwrightInstance.launch(launchOptions)
   }
 }
 
@@ -63,9 +63,10 @@ export const getPlaywrightEnv = (basicEnv = 'node') => {
     async setup(): Promise<void> {
       const { rootDir, wsEndpoint, browserName } = this._config
       const config = await readConfig(rootDir)
-      config.connectBrowserApp = { wsEndpoint }
+      config.connectOptions = { wsEndpoint }
       const browserType = getBrowserType(browserName)
-      const { context, exitOnPageError, selectors } = config
+      const { exitOnPageError, selectors } = config
+      let { contextOptions } = config
       const playwrightPackage = await readPackage()
       if (playwrightPackage === IMPORT_KIND_PLAYWRIGHT) {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -83,7 +84,6 @@ export const getPlaywrightEnv = (basicEnv = 'node') => {
         playwrightPackage,
         browserType,
       )
-      let contextOptions = context
 
       if (device) {
         const { viewport, userAgent } = devices[device]

--- a/src/PlaywrightRunner.ts
+++ b/src/PlaywrightRunner.ts
@@ -69,7 +69,7 @@ class PlaywrightRunner extends JestRunner {
     const pwTests: Test[] = []
     for (const test of tests) {
       const { rootDir } = test.context.config
-      const { browsers, devices, launchBrowserApp } = await readConfig(rootDir)
+      const { browsers, devices, launchOptions } = await readConfig(rootDir)
       for (const browser of browsers) {
         checkBrowserEnv(browser)
         const { devices: availableDevices, instance } = getPlaywrightInstance(
@@ -78,7 +78,7 @@ class PlaywrightRunner extends JestRunner {
         )
         if (!this.browser2Server[browser]) {
           this.browser2Server[browser] = await instance.launchServer(
-            launchBrowserApp,
+            launchOptions,
           )
         }
         const wsEndpoint = this.browser2Server[browser]!.wsEndpoint()

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,8 +7,8 @@ export const FIREFOX = 'firefox'
 export const WEBKIT = 'webkit'
 
 export const DEFAULT_CONFIG: Config = {
-  launchBrowserApp: {},
-  context: {},
+  launchOptions: {},
+  contextOptions: {},
   browsers: [CHROMIUM],
   devices: [],
   exitOnPageError: true,

--- a/src/global.ts
+++ b/src/global.ts
@@ -34,9 +34,9 @@ export async function setup(
     didAlreadyRunInWatchMode = true
   }
 
-  if (config.server) {
+  if (config.serverOptions) {
     try {
-      await setupServer(config.server)
+      await setupServer(config.serverOptions)
     } catch (error) {
       if (error.code === ERROR_TIMEOUT) {
         logMessage({

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -38,14 +38,14 @@ export interface Playwright {
 export type PlaywrightRequireType = BrowserType | typeof IMPORT_KIND_PLAYWRIGHT
 
 export interface Config {
-  launchBrowserApp?: LaunchOptions
-  context?: BrowserContextOptions
+  launchOptions?: LaunchOptions
+  contextOptions?: BrowserContextOptions
   exitOnPageError: boolean
   browsers: BrowserType[]
   devices?: string[]
-  server?: JestProcessManagerOptions
+  serverOptions?: JestProcessManagerOptions
   selectors?: SelectorType[]
-  connectBrowserApp?: Parameters<GenericBrowser['connect']>[0]
+  connectOptions?: Parameters<GenericBrowser['connect']>[0]
 }
 
 export interface JestPlaywrightConfig extends JestConfig.ProjectConfig {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -34,11 +34,11 @@ describe('readConfig', () => {
     jest.mock(
       path.join(__dirname, '..', 'jest-playwright.config.js'),
       () => ({
-        launchBrowserApp: {
+        launchOptions: {
           headless: true,
         },
         browser: 'chromium',
-        context: {
+        contextOptions: {
           ignoreHTTPSErrors: true,
         },
       }),
@@ -46,10 +46,10 @@ describe('readConfig', () => {
     )
     const config = await readConfig()
     const expectedConfig = {
-      launchBrowserApp: {
+      launchOptions: {
         headless: true,
       },
-      context: {
+      contextOptions: {
         ignoreHTTPSErrors: true,
       },
       browser: 'chromium',
@@ -57,17 +57,17 @@ describe('readConfig', () => {
     }
     expect(config).toMatchObject(expectedConfig)
   })
-  it('should overwrite with a custom configuration and spread the "launchBrowserApp" and "context" setting', async () => {
+  it('should overwrite with a custom configuration and spread the "launchOptions" and "contextOptions" setting', async () => {
     ;((fs.exists as unknown) as jest.Mock).mockImplementationOnce(
       (_, cb: (exists: boolean) => void) => cb(true),
     )
     jest.mock(
       path.join(__dirname, '..', 'jest-playwright.config.js'),
       () => ({
-        launchBrowserApp: {
+        launchOptions: {
           headless: true,
         },
-        context: {
+        contextOptions: {
           foo: true,
         },
       }),
@@ -75,10 +75,10 @@ describe('readConfig', () => {
     )
     const config = await readConfig()
     const expectedConfig = {
-      launchBrowserApp: {
+      launchOptions: {
         headless: true,
       },
-      context: {
+      contextOptions: {
         foo: true,
       },
       browsers: ['chromium'],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -146,13 +146,13 @@ export const readConfig = async (
   return {
     ...DEFAULT_CONFIG,
     ...localConfig,
-    launchBrowserApp: {
-      ...DEFAULT_CONFIG.launchBrowserApp,
-      ...(localConfig.launchBrowserApp || {}),
+    launchOptions: {
+      ...DEFAULT_CONFIG.launchOptions,
+      ...(localConfig.launchOptions || {}),
     },
-    context: {
-      ...DEFAULT_CONFIG.context,
-      ...(localConfig.context || {}),
+    contextOptions: {
+      ...DEFAULT_CONFIG.contextOptions,
+      ...(localConfig.contextOptions || {}),
     },
   }
 }


### PR DESCRIPTION
Definitely something which we should mention with bold text in the change log. Also thought about adding it to the code like that: if the old options are set, then throw an error message. We could also use something like that: https://www.npmjs.com/package/jest-validate