### PR TITLE
Allow skip test ability

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,11 +24,7 @@ jobs:
           ${{ runner.os }}-node-
     - name: Install dependencies
       run: npm install
-    - name: Install required apt dependencies
-      if: ${{ matrix.platform == 'ubuntu-latest' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install libgbm-dev
+    - uses: microsoft/playwright-github-action@v1
     - name: Lint Source Code
       run: npm run lint
     - name: Build project

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 coverage/
 lib/
+example-*.png

--- a/e2e/more.test.ts
+++ b/e2e/more.test.ts
@@ -1,7 +1,15 @@
+/// <reference types="./../types/global" />
 describe('Example setContext test', () => {
-  it('should be able to execute javascript', async () => {
+  it('should be able to execute javascript 1', async () => {
     page.setContent(`<script>document.write("test")</script>`)
     const element = await page.waitForSelector('text=test')
     expect(element).toBeTruthy()
+  })
+  jestPlaywright.skip({ browser: 'chromium' }, () => {
+    it('should be able to execute javascript 2', async () => {
+      page.setContent(`<script>document.write("test")</script>`)
+      const element = await page.waitForSelector('text=test')
+      expect(element).toBeTruthy()
+    })
   })
 })

--- a/e2e/stub.test.ts
+++ b/e2e/stub.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="./../types/global" />
 import path from 'path'
 
 describe('Example HTML file', () => {
@@ -5,6 +6,6 @@ describe('Example HTML file', () => {
     await page.goto(`file:${path.join(__dirname, 'example.html')}`)
     const browser = await page.$eval('h1', (el) => el.textContent)
     expect(browser).toBe('Example')
-    expect(browserName).toBe('chromium')
+    expect(browserName).toBeTruthy()
   })
 })

--- a/jest-playwright.config.js
+++ b/jest-playwright.config.js
@@ -1,0 +1,4 @@
+// https://github.com/playwright-community/jest-playwright/#configuration
+module.exports = {
+  browsers: ['chromium', 'firefox', 'webkit'],
+}

--- a/jest.config.e2e.js
+++ b/jest.config.e2e.js
@@ -4,4 +4,5 @@ module.exports = {
   runner: './runner.js',
   testPathIgnorePatterns: ['/node_modules/', 'lib'],
   testMatch: ['**/e2e/**/*.test.ts'],
+  verbose: true,
 }

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -142,12 +142,16 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
       this.global.jestPlaywright = {
         skip: (skipOption: SkipOption, callback: () => void): void => {
           const skipFlag = getSkipFlag(skipOption, browserName, deviceName)
+          const { describe, it, test } = this.global
           if (skipFlag) {
-            this.global.describe = this.global.describe.skip
-            this.global.it = this.global.it.skip
-            this.global.test = this.global.test.skip
+            this.global.describe = describe.skip
+            this.global.it = it.skip
+            this.global.test = test.skip
           }
           callback()
+          this.global.describe = describe
+          this.global.it = it
+          this.global.test = test
         },
         debug: async (): Promise<void> => {
           // Run a debugger (in case Playwright has been launched with `{ devtools: true }`)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,11 @@ import { CHROMIUM, FIREFOX, IMPORT_KIND_PLAYWRIGHT, WEBKIT } from './constants'
 
 export type BrowserType = typeof CHROMIUM | typeof FIREFOX | typeof WEBKIT
 
+export type SkipOption = {
+  browser: BrowserType
+  device?: string
+}
+
 export type CustomDeviceType = BrowserContextOptions & {
   name: string
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -24,6 +24,9 @@ beforeEach(() => {
 
 describe('readConfig', () => {
   it('should return the default configuration if there was no separate configuration specified', async () => {
+    ;((fs.exists as unknown) as jest.Mock).mockImplementationOnce(
+      (_, cb: (exists: boolean) => void) => cb(false),
+    )
     const config = await readConfig()
     expect(config).toMatchObject(DEFAULT_CONFIG)
   })

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import * as Utils from './utils'
-import { DEFAULT_CONFIG, CHROMIUM } from './constants'
+import { DEFAULT_CONFIG, CHROMIUM, FIREFOX } from './constants'
 import type { BrowserType } from './types'
 
 const {
@@ -12,6 +12,7 @@ const {
   checkDeviceEnv,
   getPlaywrightInstance,
   getDisplayName,
+  getSkipFlag,
 } = Utils
 
 jest.spyOn(fs, 'exists')
@@ -160,6 +161,38 @@ describe('checkDeviceEnv', () => {
     const device = 'unknown'
     const devices = ['iPhone 11', 'Pixel 2', 'Nexus 4']
     expect(() => checkDeviceEnv(device, devices)).toThrow()
+  })
+})
+
+describe('getSkipFlag', () => {
+  it('should return true if skipOption.browser = browserName', async () => {
+    const skipOptions = { browser: CHROMIUM as BrowserType }
+    const skipFlag = getSkipFlag(skipOptions, CHROMIUM, null)
+    expect(skipFlag).toBe(true)
+  })
+
+  it('should return false if skipOption.browser != browserName', async () => {
+    const skipOptions = { browser: CHROMIUM as BrowserType }
+    const skipFlag = getSkipFlag(skipOptions, FIREFOX, null)
+    expect(skipFlag).toBe(false)
+  })
+
+  it('should return true if skipOption.browser = browserName & skipOption.device = deviceName', async () => {
+    const skipOptions = { browser: CHROMIUM as BrowserType, device: 'Pixel 2' }
+    const skipFlag = getSkipFlag(skipOptions, CHROMIUM, 'Pixel 2')
+    expect(skipFlag).toBe(true)
+  })
+
+  it('should return false if skipOption.browser != browserName & skipOption.device = deviceName', async () => {
+    const skipOptions = { browser: CHROMIUM as BrowserType, device: 'Pixel 2' }
+    const skipFlag = getSkipFlag(skipOptions, FIREFOX, 'Pixel 2')
+    expect(skipFlag).toBe(false)
+  })
+
+  it('should return false if skipOption.browser != browserName & skipOption.device != deviceName', async () => {
+    const skipOptions = { browser: CHROMIUM as BrowserType, device: 'Pixel 2' }
+    const skipFlag = getSkipFlag(skipOptions, FIREFOX, null)
+    expect(skipFlag).toBe(false)
   })
 })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -164,7 +164,6 @@ export const getSkipFlag = (
   } else {
     return browser === browserName && device === deviceName
   }
-  return false
 }
 
 export const readConfig = async (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import type {
   JestPlaywrightConfig,
   Playwright,
   PlaywrightRequireType,
+  SkipOption,
 } from './types'
 import {
   CHROMIUM,
@@ -132,6 +133,20 @@ const validateConfig = (config: JestPlaywrightConfig) => {
   if (hasError) {
     throw new Error(formatError('Validation error occurred'))
   }
+}
+
+export const getSkipFlag = (
+  skipOptions: SkipOption,
+  browserName: BrowserType,
+  deviceName: string | null,
+): boolean => {
+  const { browser, device } = skipOptions
+  if (!device) {
+    return browser === browserName
+  } else {
+    return browser === browserName && device === deviceName
+  }
+  return false
 }
 
 export const readConfig = async (

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,6 +1,8 @@
-import { Page, Browser, BrowserContext } from 'playwright-core'
+import type { Page, Browser, BrowserContext } from 'playwright-core'
+import type { SkipOption } from '../src/types'
 
 interface JestPlaywright {
+  skip: (skipOptions: SkipOption) => void
   /**
    * Suspends test execution and gives you opportunity to see what's going on in the browser
    * - Jest is suspended (no timeout)
@@ -30,7 +32,7 @@ interface JestPlaywright {
 
 declare global {
   const browserName: string
-  const deviceName: string
+  const deviceName: string | null
   const page: Page
   const browser: Browser
   const context: BrowserContext

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,7 +2,7 @@ import type { Page, Browser, BrowserContext } from 'playwright-core'
 import type { SkipOption } from '../src/types'
 
 interface JestPlaywright {
-  skip: (skipOptions: SkipOption) => void
+  skip: (skipOptions: SkipOption, callback: Function) => void
   /**
    * Suspends test execution and gives you opportunity to see what's going on in the browser
    * - Jest is suspended (no timeout)


### PR DESCRIPTION
close #174 
It will be able through `jestPlaywright` object:
```js
    // You can pass browser and device by the first argument
    jestPlaywright.skip({ browser: 'chromium' }, () => {
        // it will be able to use `describe` or `it`
        test('should display "google" text on page', async () => {
            const title = await page.title()
            expect(title).toBe('Google')
        })

        test('test 2', () => {
            expect(1).toBe(1)
        })
    })
```