### PR TITLE
Add ability to use RegExp pattern to define devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,36 @@ You can specify a `jest-playwright.config.js` at the root of the project or defi
   - `chromium` Each test runs Chromium (default).
   - `firefox` Each test runs Firefox.
   - `webkit` Each test runs Webkit.
-- `devices` <[string[]]>. Define a [devices](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsertypedevices) to run tests in. Actual list of devices can be found [here](https://github.com/Microsoft/playwright/blob/master/src/deviceDescriptors.ts). Also you can define custom device:
+- `devices` <[(string | object)[] | RegExp]>. Define a [devices](https://github.com/microsoft/playwright/blob/master/docs/api.md#browsertypedevices) to run tests in. Actual list of devices can be found [here](https://github.com/Microsoft/playwright/blob/master/src/deviceDescriptors.ts).
+
+- `exitOnPageError` <[boolean]>. Exits process on any page error. Defaults to `true`.
+- `collectCoverage` <[boolean]>. Enables the coverage collection of the `saveCoverage(page)` calls to the `.nyc_output/coverage.json` file.
+- `serverOptions` <[object]>. [All `jest-dev-server` options](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-dev-server#options).
+- `selectors` <[array]>. Define [selectors](https://github.com/microsoft/playwright/blob/v0.11.1/docs/api.md#class-selectors). Each selector must be an object with name and script properties.
+
+### Device configuration
+
+There are different ways to define browsers in your tests:
+
+- You can you array of device names:
+
+```js
+module.exports = {
+  devices: ["iPhone 6", "Pixel 2"],
+  ...
+}
+```
+
+- You can use **RegExp**:
+
+```js
+module.exports = {
+  devices: /iPhone 8/,
+  ...
+}
+```
+
+- Also you can define custom device:
 
 ```js
 {
@@ -104,12 +133,7 @@ You can specify a `jest-playwright.config.js` at the root of the project or defi
 }
 ```
 
-- `exitOnPageError` <[boolean]>. Exits process on any page error. Defaults to `true`.
-- `collectCoverage` <[boolean]>. Enables the coverage collection of the `saveCoverage(page)` calls to the `.nyc_output/coverage.json` file.
-- `serverOptions` <[object]>. [All `jest-dev-server` options](https://github.com/smooth-code/jest-puppeteer/tree/master/packages/jest-dev-server#options).
-- `selectors` <[array]>. Define [selectors](https://github.com/microsoft/playwright/blob/v0.11.1/docs/api.md#class-selectors). Each selector must be an object with name and script properties.
-
-Usage with [query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom) in `jest-playwright.config.js`:
+### Usage with [query-selector-shadow-dom](https://github.com/Georgegriff/query-selector-shadow-dom) in `jest-playwright.config.js`:
 
 ```javascript
 const {

--- a/src/PlaywrightRunner.ts
+++ b/src/PlaywrightRunner.ts
@@ -11,6 +11,7 @@ import type {
 import type { Config as JestConfig } from '@jest/types'
 import type {
   BrowserType,
+  CustomDeviceType,
   DeviceType,
   WsEndpointType,
   JestPlaywrightTest,
@@ -73,6 +74,7 @@ class PlaywrightRunner extends JestRunner {
 
   async getTests(tests: Test[], config: JestPlaywrightConfig): Promise<Test[]> {
     const { browsers, devices, launchType, launchOptions } = config
+    let resultDevices: (string | CustomDeviceType)[] = []
     const pwTests: Test[] = []
     for (const test of tests) {
       for (const browser of browsers) {
@@ -89,8 +91,18 @@ class PlaywrightRunner extends JestRunner {
           wsEndpoint = this.browser2Server[browser]!.wsEndpoint()
         }
 
-        if (devices && devices.length) {
-          devices.forEach((device: DeviceType) => {
+        if (devices instanceof RegExp) {
+          resultDevices = Object.keys(availableDevices).filter((item) =>
+            item.match(devices),
+          )
+        } else {
+          if (devices) {
+            resultDevices = devices
+          }
+        }
+
+        if (resultDevices.length) {
+          resultDevices.forEach((device: DeviceType) => {
             if (typeof device === 'string') {
               const availableDeviceNames = Object.keys(availableDevices)
               checkDeviceEnv(device, availableDeviceNames)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,7 +25,7 @@ export type BrowserType = typeof CHROMIUM | typeof FIREFOX | typeof WEBKIT
 
 export type SkipOption = {
   browser: BrowserType
-  device?: string
+  device?: string | RegExp
 }
 
 export type CustomDeviceType = BrowserContextOptions & {
@@ -69,7 +69,7 @@ export interface JestPlaywrightConfig {
   userDataDir?: string
   exitOnPageError: boolean
   browsers: BrowserType[]
-  devices?: (string | CustomDeviceType)[]
+  devices?: (string | CustomDeviceType)[] | RegExp
   serverOptions?: JestProcessManagerOptions
   selectors?: SelectorType[]
   collectCoverage: boolean

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -207,6 +207,12 @@ describe('getSkipFlag', () => {
   })
 
   it('should return true if skipOption.browser = browserName & skipOption.device = deviceName', async () => {
+    const skipOptions = { browser: CHROMIUM as BrowserType, device: /Pixel/ }
+    const skipFlag = getSkipFlag(skipOptions, CHROMIUM, 'Pixel 2')
+    expect(skipFlag).toBe(true)
+  })
+
+  it('should return true if skipOption.device is RegExp', async () => {
     const skipOptions = { browser: CHROMIUM as BrowserType, device: 'Pixel 2' }
     const skipFlag = getSkipFlag(skipOptions, CHROMIUM, 'Pixel 2')
     expect(skipFlag).toBe(true)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -162,6 +162,9 @@ export const getSkipFlag = (
   if (!device) {
     return browser === browserName
   } else {
+    if (device instanceof RegExp) {
+      return browser === browserName && device.test(deviceName!)
+    }
     return browser === browserName && device === deviceName
   }
 }


### PR DESCRIPTION
Just think that the using of **RegExp** will be helpful to define devices.
```js
// jest-playwright.config.js
module.exports = {
    ...
    devices: /iPhone 8/
}
```

Will run tests for **iPhone 8**, **iPhone 8 landscape**, **iPhone 8 Plus** and **iPhone 8 Plus landscape**.

Also it will be able for skip test.