### PR TITLE
Fix global types

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,5 +1,9 @@
 import type { Page, Browser, BrowserContext } from 'playwright-core'
-import type { SkipOption } from '../src/types'
+
+type SkipOption = {
+  browser: 'chromium' | 'firefox' | 'webkit'
+  device?: string | RegExp
+}
 
 interface JestPlaywright {
   skip: (skipOptions: SkipOption, callback: Function) => void

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,7 +1,9 @@
 import type { Page, Browser, BrowserContext } from 'playwright-core'
 
+type BrowserType = 'chromium' | 'firefox' | 'webkit'
+
 type SkipOption = {
-  browser: 'chromium' | 'firefox' | 'webkit'
+  browser: BrowserType
   device?: string | RegExp
 }
 
@@ -65,7 +67,7 @@ interface JestPlaywright {
 }
 
 declare global {
-  const browserName: string
+  const browserName: BrowserType
   const deviceName: string | null
   const page: Page
   const browser: Browser


### PR DESCRIPTION
close #205 

@mxschmitt I don't have a nice way to do it. But seems like we can't include **types** from the **src** directory, cause we will need also include **constants**, cause internal types use them. 