### PR TITLE
jestPlaywright skip improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,12 @@ npx nyc report --reporter=html
 
 which will create a HTML website in the `coverage` directory.
 
-## Skip tests for specific browser and device
+## Skip tests for specific browsers and devices
 
-It's possible to skip tests for browser or combination of browser and device
+It's possible to skip tests for browsers or combination of browsers and devices
 
 ```js
-jestPlaywright.skip({ browser: 'chromium' }, () => {
+jestPlaywright.skip({ browsers: ['chromium'] }, () => {
   test('should skip this one', async () => {
     const title = await page.title()
     expect(title).toBe('Google')

--- a/e2e/more.test.ts
+++ b/e2e/more.test.ts
@@ -5,7 +5,7 @@ describe('Example setContext test', () => {
     const element = await page.waitForSelector('text=test')
     expect(element).toBeTruthy()
   })
-  jestPlaywright.skip({ browser: 'chromium' }, () => {
+  jestPlaywright.skip({ browsers: ['chromium'] }, () => {
     it('should be able to execute javascript 2', async () => {
       page.setContent(`<script>document.write("test")</script>`)
       const element = await page.waitForSelector('text=test')

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -24,8 +24,8 @@ import {
 export type BrowserType = typeof CHROMIUM | typeof FIREFOX | typeof WEBKIT
 
 export type SkipOption = {
-  browser: BrowserType
-  device?: string | RegExp
+  browsers: BrowserType[]
+  devices?: string[] | RegExp
 }
 
 export type CustomDeviceType = BrowserContextOptions & {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -204,38 +204,50 @@ describe('checkDeviceEnv', () => {
 })
 
 describe('getSkipFlag', () => {
-  it('should return true if skipOption.browser = browserName', async () => {
-    const skipOptions = { browser: CHROMIUM as BrowserType }
+  it('should return true if skipOption.browsers includes browserName', async () => {
+    const skipOptions = { browsers: [CHROMIUM as BrowserType] }
     const skipFlag = getSkipFlag(skipOptions, CHROMIUM, null)
     expect(skipFlag).toBe(true)
   })
 
-  it('should return false if skipOption.browser != browserName', async () => {
-    const skipOptions = { browser: CHROMIUM as BrowserType }
+  it('should return false if skipOption.browsers does not include browserName', async () => {
+    const skipOptions = { browsers: [CHROMIUM as BrowserType] }
     const skipFlag = getSkipFlag(skipOptions, FIREFOX, null)
     expect(skipFlag).toBe(false)
   })
 
-  it('should return true if skipOption.browser = browserName & skipOption.device = deviceName', async () => {
-    const skipOptions = { browser: CHROMIUM as BrowserType, device: /Pixel/ }
+  it('should return true if skipOption.browser includes browserName & skipOption.devices includes deviceName', async () => {
+    const skipOptions = {
+      browsers: [CHROMIUM as BrowserType],
+      devices: /Pixel/,
+    }
     const skipFlag = getSkipFlag(skipOptions, CHROMIUM, 'Pixel 2')
     expect(skipFlag).toBe(true)
   })
 
-  it('should return true if skipOption.device is RegExp', async () => {
-    const skipOptions = { browser: CHROMIUM as BrowserType, device: 'Pixel 2' }
+  it('should return true if skipOption.devices is RegExp and match to deviceName', async () => {
+    const skipOptions = {
+      browsers: [CHROMIUM as BrowserType],
+      devices: ['Pixel 2'],
+    }
     const skipFlag = getSkipFlag(skipOptions, CHROMIUM, 'Pixel 2')
     expect(skipFlag).toBe(true)
   })
 
-  it('should return false if skipOption.browser != browserName & skipOption.device = deviceName', async () => {
-    const skipOptions = { browser: CHROMIUM as BrowserType, device: 'Pixel 2' }
+  it('should return false if skipOption.browser does not include browserName & skipOption.devices includes deviceName', async () => {
+    const skipOptions = {
+      browsers: [CHROMIUM as BrowserType],
+      devices: ['Pixel 2'],
+    }
     const skipFlag = getSkipFlag(skipOptions, FIREFOX, 'Pixel 2')
     expect(skipFlag).toBe(false)
   })
 
-  it('should return false if skipOption.browser != browserName & skipOption.device != deviceName', async () => {
-    const skipOptions = { browser: CHROMIUM as BrowserType, device: 'Pixel 2' }
+  it('should return false if skipOption.browser does not includes browserName & skipOption.devices does not include deviceName', async () => {
+    const skipOptions = {
+      browsers: [CHROMIUM as BrowserType],
+      devices: ['Pixel 2'],
+    }
     const skipFlag = getSkipFlag(skipOptions, FIREFOX, null)
     expect(skipFlag).toBe(false)
   })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,14 +157,15 @@ export const getSkipFlag = (
   browserName: BrowserType,
   deviceName: string | null,
 ): boolean => {
-  const { browser, device } = skipOptions
-  if (!device) {
-    return browser === browserName
+  const { browsers, devices } = skipOptions
+  const isBrowserIncluded = browsers.includes(browserName)
+  if (!devices) {
+    return isBrowserIncluded
   } else {
-    if (device instanceof RegExp) {
-      return browser === browserName && device.test(deviceName!)
+    if (devices instanceof RegExp) {
+      return isBrowserIncluded && devices.test(deviceName!)
     }
-    return browser === browserName && device === deviceName
+    return isBrowserIncluded && devices.includes(deviceName!)
   }
 }
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -11,8 +11,8 @@ import type {
 type BrowserType = 'chromium' | 'firefox' | 'webkit'
 
 type SkipOption = {
-  browser: BrowserType
-  device?: string | RegExp
+  browsers: BrowserType[]
+  devices?: string[] | RegExp
 }
 
 type GenericBrowser = PlaywrightBrowserType<


### PR DESCRIPTION
coming from https://github.com/playwright-community/jest-playwright/issues/174#issuecomment-657850012

I suppose that `jestPlaywright.skip` method should take options like `jest-playwright.config` to be consistence.

**Before:** 
```js
jestPlaywright.skip({ browser: 'chromium', device: 'Pixel 2' }, () => {
  test('should skip this one', async () => {
    const title = await page.title()
    expect(title).toBe('Google')
  })

  test('and this one', () => {
    expect(1).toBe(2)
  })
})
```

**After:**
```js
jestPlaywright.skip({ browsers: ['chromium'], devices: ['Pixel 2'] }, () => {
  test('should skip this one', async () => {
    const title = await page.title()
    expect(title).toBe('Google')
  })

  test('and this one', () => {
    expect(1).toBe(2)
  })
})
```