### PR TITLE
Fix ts global declaration

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   Page,
   Browser,
   BrowserContext,


### PR DESCRIPTION
Import types was added only in **3.8**.
I suppose we should remove it to support earlier versions. Originally came from https://github.com/playwright-community/jest-playwright/issues/181