### PR TITLE
Add ability to configure playwright in test file

### DIFF
--- a/extends.js
+++ b/extends.js
@@ -1,4 +1,4 @@
-/* global jestPlaywright */
+/* global jestPlaywright, browserName */
 const DEBUG_OPTIONS = {
   launchType: 'LAUNCH',
   launchOptions: {
@@ -22,15 +22,23 @@ it.jestPlaywrightDebug = (...args) => {
 }
 
 it.jestPlaywrightConfig = (playwrightOptions, ...args) => {
-  it(args[0], async () => {
-    const { browser, context, page } = await jestPlaywright._configSeparateEnv({
-      ...DEBUG_OPTIONS,
-      playwrightOptions,
+  if (playwrightOptions.browser && playwrightOptions.browser !== browserName) {
+    it.skip(...args)
+  } else {
+    it(args[0], async () => {
+      const {
+        browser,
+        context,
+        page,
+      } = await jestPlaywright._configSeparateEnv({
+        ...DEBUG_OPTIONS,
+        playwrightOptions,
+      })
+      try {
+        await args[1]({ browser, context, page })
+      } finally {
+        await browser.close()
+      }
     })
-    try {
-      await args[1]({ browser, context, page })
-    } finally {
-      await browser.close()
-    }
-  })
+  }
 }

--- a/extends.js
+++ b/extends.js
@@ -1,0 +1,36 @@
+/* global jestPlaywright */
+const DEBUG_OPTIONS = {
+  launchType: 'LAUNCH',
+  launchOptions: {
+    headless: false,
+    devtools: true,
+  },
+}
+
+it.jestPlaywrightDebug = (...args) => {
+  // TODO Add some input validation
+  it(args[0], async () => {
+    const { browser, context, page } = await jestPlaywright._configSeparateEnv(
+      DEBUG_OPTIONS,
+    )
+    try {
+      await args[1]({ browser, context, page })
+    } finally {
+      await browser.close()
+    }
+  })
+}
+
+it.jestPlaywrightConfig = (playwrightOptions, ...args) => {
+  it(args[0], async () => {
+    const { browser, context, page } = await jestPlaywright._configSeparateEnv({
+      ...DEBUG_OPTIONS,
+      playwrightOptions,
+    })
+    try {
+      await args[1]({ browser, context, page })
+    } finally {
+      await browser.close()
+    }
+  })
+}

--- a/extends.js
+++ b/extends.js
@@ -8,7 +8,10 @@ const DEBUG_OPTIONS = {
 }
 
 it.jestPlaywrightDebug = (...args) => {
-  // TODO Add some input validation
+  // TODO:
+  //  1. Add input validation
+  //  2. Unite jestPlaywrightDebug and jestPlaywrightConfig in one function
+  //  3. Check out passing config to jestPlaywright._configSeparateEnv
   it(args[0], async () => {
     const { browser, context, page } = await jestPlaywright._configSeparateEnv(
       DEBUG_OPTIONS,

--- a/jest-preset.json
+++ b/jest-preset.json
@@ -5,6 +5,7 @@
   "runner": "jest-playwright-preset/runner.js",
   "testRunner": "jest-circus/runner",
   "setupFilesAfterEnv": [
-    "expect-playwright"
+    "expect-playwright",
+    "jest-playwright-preset/extends.js"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1744,15 +1744,6 @@
         }
       }
     },
-    "@typescript-eslint/visitor-keys": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.6.1.tgz",
-      "integrity": "sha512-qC8Olwz5ZyMTZrh4Wl3K4U6tfms0R/mzU4/5W3XeUZptVraGVmbptJbn6h2Ey6Rb3hOs3zWoAUebZk8t47KGiQ==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^1.1.0"
-      }
-    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -180,10 +180,9 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
           this.global.it = it
           this.global.test = test
         },
-        config: async (
+        _configSeparateEnv: async (
           config: JestPlaywrightConfig,
-          callback: ({ browser, context, page }: ConfigParams) => void,
-        ): Promise<void> => {
+        ): Promise<ConfigParams> => {
           const { contextOptions, launchType } = config
           const browserOrContext = await getBrowserPerProcess(
             playwrightInstance,
@@ -203,16 +202,7 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
               ? (browserOrContext as BrowserContext)
               : await (browser as Browser)!.newContext(newContextOptions)
           const page = await context!.newPage()
-          const runTest = async ({ browser, context, page }: ConfigParams) => {
-            await callback({ browser, context, page })
-          }
-          try {
-            await runTest({ browser, context, page })
-          } finally {
-            if (browser) {
-              await browser.close()
-            }
-          }
+          return { browser, context, page }
         },
         resetPage: async (): Promise<void> => {
           const { context, page } = this.global

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -180,6 +180,30 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
           this.global.it = it
           this.global.test = test
         },
+        config: async (
+          config: JestPlaywrightConfig,
+          callback: ({ browser, context, page }) => void,
+        ): Promise<void> => {
+          const browser = await getBrowserPerProcess(
+            playwrightInstance,
+            browserType,
+            { ...this._jestPlaywrightConfig, ...config },
+          )
+          const newContextOptions = getBrowserOptions(
+            browserName,
+            config.contextOptions,
+          )
+          const context = await browser.newContext(newContextOptions)
+          const page = await context.newPage()
+          const runTest = async ({ browser, context, page }) => {
+            await callback({ browser, context, page })
+          }
+          try {
+            await runTest({ browser, context, page })
+          } finally {
+            await browser.close()
+          }
+        },
         resetPage: async (): Promise<void> => {
           const { context, page } = this.global
           if (page) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -36,8 +36,6 @@ export type DeviceType = CustomDeviceType | string | null
 
 export type WsEndpointType = string | null
 
-export type Packages = Partial<Record<BrowserType, BrowserType>>
-
 export type GenericBrowser = PlaywrightBrowserType<
   WebKitBrowser | ChromiumBrowser | FirefoxBrowser
 >


### PR DESCRIPTION
#216 

Seems to be a bit challenging to implement this in a nice way. IDK if it will be helpful to configure **playwright** for just one test. The only founded solution was to use isolation playwright configuration.
It will be smth like that:
```js
describe('Simple tests',  () => {
    beforeAll(async () => {
        await page.goto('https://google.com/')
    })

    test('test1', async () => {
        await jestPlaywright.config({
            browser: 'chromium',
            launchType: "LAUNCH",
            launchOptions: {
                headless: false,
                devtools: true,
            }
        }, async ({page}) => {
            // page is coming from function params
            await page.goto('https://github.com/')
            const title = await page.title()
            expect(title).toBe('Google')
        })
    })

    test('test2', async () => {
        const title = await page.title()
        expect(title).toBe('Google')
    })

    afterAll(async () => {
        await page.close()
    });
})
```

Also IDK the way of passing config. Should we merge `jest-playwright` config or we should use only config, passed throw `jestPlaywright.config` function