### PR TITLE
Change jestPlaywright skip API

### DIFF
--- a/e2e/more.test.ts
+++ b/e2e/more.test.ts
@@ -5,11 +5,15 @@ describe('Example setContext test', () => {
     const element = await page.waitForSelector('text=test')
     expect(element).toBeTruthy()
   })
-  jestPlaywright.skip({ browsers: ['chromium'] }, () => {
-    it('should be able to execute javascript 2', async () => {
+  // TODO remove ts-ignore
+  //@ts-ignore
+  it.jestPlaywrightSkip(
+    { browsers: ['chromium'] },
+    'should be able to execute javascript 2',
+    async () => {
       page.setContent(`<script>document.write("test")</script>`)
       const element = await page.waitForSelector('text=test')
       expect(element).toBeTruthy()
-    })
-  })
+    },
+  )
 })

--- a/e2e/more.test.ts
+++ b/e2e/more.test.ts
@@ -5,7 +5,7 @@ describe('Example setContext test', () => {
     const element = await page.waitForSelector('text=test')
     expect(element).toBeTruthy()
   })
-  jestPlaywright.skip(
+  it.jestPlaywrightSkip(
     { browsers: ['chromium'] },
     'should be able to execute javascript 2',
     async () => {

--- a/e2e/more.test.ts
+++ b/e2e/more.test.ts
@@ -5,9 +5,7 @@ describe('Example setContext test', () => {
     const element = await page.waitForSelector('text=test')
     expect(element).toBeTruthy()
   })
-  // TODO remove ts-ignore
-  //@ts-ignore
-  it.jestPlaywrightSkip(
+  jestPlaywright.skip(
     { browsers: ['chromium'] },
     'should be able to execute javascript 2',
     async () => {

--- a/extends.js
+++ b/extends.js
@@ -1,4 +1,6 @@
-/* global jestPlaywright, browserName */
+/* global jestPlaywright, browserName, deviceName */
+const { getSkipFlag } = require('./lib/utils')
+
 const DEBUG_OPTIONS = {
   launchType: 'LAUNCH',
   launchOptions: {
@@ -44,4 +46,21 @@ it.jestPlaywrightConfig = (playwrightOptions, ...args) => {
       }
     })
   }
+}
+
+const customSkip = (skipOption, type, ...args) => {
+  const skipFlag = getSkipFlag(skipOption, browserName, deviceName)
+  if (skipFlag) {
+    global[type].skip(...args)
+  } else {
+    global[type](...args)
+  }
+}
+
+it.jestPlaywrightSkip = (skipOption, ...args) => {
+  customSkip(skipOption, 'it', ...args)
+}
+
+describe.jestPlaywrightSkip = (skipOption, ...args) => {
+  customSkip(skipOption, 'describe', ...args)
 }

--- a/extends.js
+++ b/extends.js
@@ -10,10 +10,7 @@ const DEBUG_OPTIONS = {
 }
 
 it.jestPlaywrightDebug = (...args) => {
-  // TODO:
-  //  1. Add input validation
-  //  2. Unite jestPlaywrightDebug and jestPlaywrightConfig in one function
-  //  3. Check out passing config to jestPlaywright._configSeparateEnv
+  // TODO: Check out passing config to jestPlaywright._configSeparateEnv
   it(args[0], async () => {
     const { browser, context, page } = await jestPlaywright._configSeparateEnv(
       DEBUG_OPTIONS,
@@ -57,6 +54,7 @@ const customSkip = (skipOption, type, ...args) => {
   }
 }
 
+// TODO Put information about changes in Readme before 1.3.0
 it.jestPlaywrightSkip = (skipOption, ...args) => {
   customSkip(skipOption, 'it', ...args)
 }

--- a/jest.config.e2e.js
+++ b/jest.config.e2e.js
@@ -4,5 +4,6 @@ module.exports = {
   runner: './runner.js',
   testPathIgnorePatterns: ['/node_modules/', 'lib'],
   testMatch: ['**/e2e/**/*.test.ts'],
+  setupFilesAfterEnv: ['./extends.js'],
   verbose: true,
 }

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -167,19 +167,6 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
         this.global.page.on('pageerror', handleError)
       }
       this.global.jestPlaywright = {
-        skip: (skipOption: SkipOption, callback: () => void): void => {
-          const skipFlag = getSkipFlag(skipOption, browserName, deviceName)
-          const { describe, it, test } = this.global
-          if (skipFlag) {
-            this.global.describe = describe.skip
-            this.global.it = it.skip
-            this.global.test = test.skip
-          }
-          callback()
-          this.global.describe = describe
-          this.global.it = it
-          this.global.test = test
-        },
         _configSeparateEnv: async (
           config: JestPlaywrightConfig,
         ): Promise<ConfigParams> => {

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -6,7 +6,6 @@ import type {
   GenericBrowser,
   BrowserType,
   JestPlaywrightJestConfig,
-  SkipOption,
   ConnectOptions,
 } from './types'
 import {
@@ -20,7 +19,6 @@ import {
   getBrowserType,
   getDeviceType,
   getPlaywrightInstance,
-  getSkipFlag,
   readConfig,
 } from './utils'
 import { saveCoverageOnPage, saveCoverageToFile } from './coverage'

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -10,11 +10,6 @@ import {
 
 type BrowserType = 'chromium' | 'firefox' | 'webkit'
 
-type SkipOption = {
-  browsers: BrowserType[]
-  devices?: string[] | RegExp
-}
-
 type GenericBrowser = PlaywrightBrowserType<
   WebKitBrowser | ChromiumBrowser | FirefoxBrowser
 >
@@ -22,7 +17,6 @@ type GenericBrowser = PlaywrightBrowserType<
 type ContextOptions = Parameters<GenericBrowser['connect']>[0]
 
 interface JestPlaywright {
-  skip: (skipOptions: SkipOption, callback: Function) => void
   /**
    * Reset global.page
    *

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -21,6 +21,10 @@ type SkipOption = {
 
 type ContextOptions = Parameters<GenericBrowser['connect']>[0]
 
+interface JestParams<T> {
+  (options: T, name: string, fn?: jest.ProvidesCallback, timeout?: number): void
+}
+
 interface JestPlaywright {
   /**
    * Reset global.page
@@ -88,12 +92,14 @@ declare global {
   const jestPlaywright: JestPlaywright
   namespace jest {
     interface It {
-      jestPlaywrightSkip(
-        skipOption: SkipOption,
+      jestPlaywrightSkip: JestParams<SkipOption>
+      jestPlaywrightDebug: (
         name: string,
-        fn?: ProvidesCallback,
+        fn?: jest.ProvidesCallback,
         timeout?: number,
-      ): void
+      ) => void
+      // TODO Replace any
+      jestPlaywrightConfig: JestParams<any>
     }
   }
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -14,9 +14,20 @@ type GenericBrowser = PlaywrightBrowserType<
   WebKitBrowser | ChromiumBrowser | FirefoxBrowser
 >
 
+type SkipOption = {
+  browsers: BrowserType[]
+  devices?: string[] | RegExp
+}
+
 type ContextOptions = Parameters<GenericBrowser['connect']>[0]
 
 interface JestPlaywright {
+  skip: (
+    options: SkipOption,
+    name: string,
+    fn?: jest.ProvidesCallback,
+    timeout?: number,
+  ) => void
   /**
    * Reset global.page
    *

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -22,12 +22,6 @@ type SkipOption = {
 type ContextOptions = Parameters<GenericBrowser['connect']>[0]
 
 interface JestPlaywright {
-  skip: (
-    options: SkipOption,
-    name: string,
-    fn?: jest.ProvidesCallback,
-    timeout?: number,
-  ) => void
   /**
    * Reset global.page
    *
@@ -92,4 +86,14 @@ declare global {
   const browser: Browser
   const context: BrowserContext
   const jestPlaywright: JestPlaywright
+  namespace jest {
+    interface It {
+      jestPlaywrightSkip(
+        skipOption: SkipOption,
+        name: string,
+        fn?: ProvidesCallback,
+        timeout?: number,
+      ): void
+    }
+  }
 }


### PR DESCRIPTION
Replaced current logic:
```js
jestPlaywright.skip({ browsers: ['chromium'] }, () => {
  test('should skip this one', async () => {
    const title = await page.title()
    expect(title).toBe('Google')
  })
})
```

with
```js
it.jestPlaywrightSkip({ browsers: ['chromium'] }, 'should skip this one', async () => {
    const title = await page.title()
    expect(title).toBe('Google')
})
```