### PR TITLE
jestPlaywright debug improvements

### DIFF
--- a/extends.js
+++ b/extends.js
@@ -10,10 +10,11 @@ const DEBUG_OPTIONS = {
 }
 
 it.jestPlaywrightDebug = (...args) => {
-  // TODO: Check out passing config to jestPlaywright._configSeparateEnv
+  // TODO: Add ability to pass config with the first argument
   it(args[0], async () => {
     const { browser, context, page } = await jestPlaywright._configSeparateEnv(
       DEBUG_OPTIONS,
+      true,
     )
     try {
       await args[1]({ browser, context, page })
@@ -32,10 +33,7 @@ it.jestPlaywrightConfig = (playwrightOptions, ...args) => {
         browser,
         context,
         page,
-      } = await jestPlaywright._configSeparateEnv({
-        ...DEBUG_OPTIONS,
-        playwrightOptions,
-      })
+      } = await jestPlaywright._configSeparateEnv(playwrightOptions)
       try {
         await args[1]({ browser, context, page })
       } finally {

--- a/extends.js
+++ b/extends.js
@@ -10,7 +10,7 @@ const DEBUG_OPTIONS = {
 }
 
 it.jestPlaywrightDebug = (...args) => {
-  const isConfigProvided = args.length > 2 && typeof args[0] === 'object'
+  const isConfigProvided = typeof args[0] === 'object'
   // TODO Looks wierd - need to be rewritten
   let options = DEBUG_OPTIONS
   if (isConfigProvided) {

--- a/extends.js
+++ b/extends.js
@@ -10,14 +10,30 @@ const DEBUG_OPTIONS = {
 }
 
 it.jestPlaywrightDebug = (...args) => {
-  // TODO: Add ability to pass config with the first argument
-  it(args[0], async () => {
+  const isConfigProvided = args.length > 2 && typeof args[0] === 'object'
+  // TODO Looks wierd - need to be rewritten
+  let options = DEBUG_OPTIONS
+  if (isConfigProvided) {
+    const {
+      contextOptions,
+      launchOptions = {},
+      launchType = DEBUG_OPTIONS.launchType,
+    } = args[0]
+    options = {
+      ...DEBUG_OPTIONS,
+      launchType,
+      launchOptions: { ...DEBUG_OPTIONS.launchOptions, ...launchOptions },
+      contextOptions,
+    }
+  }
+
+  it(args[isConfigProvided ? 1 : 0], async () => {
     const { browser, context, page } = await jestPlaywright._configSeparateEnv(
-      DEBUG_OPTIONS,
+      options,
       true,
     )
     try {
-      await args[1]({ browser, context, page })
+      await args[isConfigProvided ? 2 : 1]({ browser, context, page })
     } finally {
       await browser.close()
     }


### PR DESCRIPTION
Some improvements to debug helpers:
```js
// DEBUG uses `debugOptions` config
test.jestPlaywrightDebug('test1', async () => {
  // ...
});

// DEBUG with configuration object merges options with `debugOptions` config
test.jestPlaywrightDebug({ /* ... */ }, 'test2', async () => {
  // ...
});

// CONFIG must pass a configuration object and merges passed options with primary config
test.jestPlaywrightConfig({ /* ... */ }, 'test3', async () => {
  // ...
});
```