### PR TITLE
jestPlaywright helpers skip and only

### DIFF
--- a/extends.js
+++ b/extends.js
@@ -9,7 +9,7 @@ const DEBUG_OPTIONS = {
   },
 }
 
-it.jestPlaywrightDebug = (...args) => {
+const runDebugTest = (jestTestType, ...args) => {
   const isConfigProvided = typeof args[0] === 'object'
   // TODO Looks wierd - need to be rewritten
   let options = DEBUG_OPTIONS
@@ -27,7 +27,7 @@ it.jestPlaywrightDebug = (...args) => {
     }
   }
 
-  it(args[isConfigProvided ? 1 : 0], async () => {
+  jestTestType(args[isConfigProvided ? 1 : 0], async () => {
     const { browser, context, page } = await jestPlaywright._configSeparateEnv(
       options,
       true,
@@ -40,11 +40,23 @@ it.jestPlaywrightDebug = (...args) => {
   })
 }
 
-it.jestPlaywrightConfig = (playwrightOptions, ...args) => {
+it.jestPlaywrightDebug = (...args) => {
+  runDebugTest(it, ...args)
+}
+
+it.jestPlaywrightDebug.only = (...args) => {
+  runDebugTest(it.only, ...args)
+}
+
+it.jestPlaywrightDebug.skip = (...args) => {
+  runDebugTest(it.skip, ...args)
+}
+
+const runConfigTest = (jestTypeTest, playwrightOptions, ...args) => {
   if (playwrightOptions.browser && playwrightOptions.browser !== browserName) {
     it.skip(...args)
   } else {
-    it(args[0], async () => {
+    jestTypeTest(args[0], async () => {
       const {
         browser,
         context,
@@ -57,6 +69,18 @@ it.jestPlaywrightConfig = (playwrightOptions, ...args) => {
       }
     })
   }
+}
+
+it.jestPlaywrightConfig = (playwrightOptions, ...args) => {
+  runConfigTest(it, playwrightOptions, ...args)
+}
+
+it.jestPlaywrightConfig.only = (...args) => {
+  runConfigTest(it.only, ...args)
+}
+
+it.jestPlaywrightConfig.skip = (...args) => {
+  runConfigTest(it.skip, ...args)
 }
 
 const customSkip = (skipOption, type, ...args) => {

--- a/extends.js
+++ b/extends.js
@@ -19,6 +19,7 @@ const runDebugTest = (jestTestType, ...args) => {
       launchOptions = {},
       launchType = DEBUG_OPTIONS.launchType,
     } = args[0]
+    // TODO Add function for deep objects merging
     options = {
       ...DEBUG_OPTIONS,
       launchType,

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -181,6 +181,7 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
             resultBrowserConfig = config
             resultContextOptions = contextOptions
           } else {
+            // TODO Add function for deep objects merging
             resultBrowserConfig = {
               ...this._jestPlaywrightConfig,
               launchType,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -202,6 +202,7 @@ export const readConfig = async (
 
   const localConfig = await require(absConfigPath)
   validateConfig(localConfig)
+  // TODO Add function for deep objects merging
   return {
     ...DEFAULT_CONFIG,
     ...localConfig,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -21,10 +21,6 @@ type SkipOption = {
 
 type ContextOptions = Parameters<GenericBrowser['connect']>[0]
 
-interface JestParams<T> {
-  (options: T, name: string, fn?: jest.ProvidesCallback, timeout?: number): void
-}
-
 interface JestPlaywright {
   /**
    * Reset global.page
@@ -83,6 +79,22 @@ interface JestPlaywright {
   saveCoverage: (page: Page) => Promise<void>
 }
 
+interface JestParams<T> {
+  (options: T, name: string, fn?: jest.ProvidesCallback, timeout?: number): void
+}
+
+// TODO Replace any
+interface JestPlaywrightDebug extends JestParams<any> {
+  (name: string, fn?: jest.ProvidesCallback, timeout?: number): void
+  skip: JestParams<any> | JestPlaywrightDebug
+  only: JestParams<any> | JestPlaywrightDebug
+}
+
+interface JestPlaywrightConfig extends JestParams<any> {
+  skip: JestParams<any> | JestPlaywrightConfig
+  only: JestParams<any> | JestPlaywrightConfig
+}
+
 declare global {
   const browserName: BrowserType
   const deviceName: string | null
@@ -93,13 +105,8 @@ declare global {
   namespace jest {
     interface It {
       jestPlaywrightSkip: JestParams<SkipOption>
-      jestPlaywrightDebug: (
-        name: string,
-        fn?: jest.ProvidesCallback,
-        timeout?: number,
-      ) => void
-      // TODO Replace any
-      jestPlaywrightConfig: JestParams<any>
+      jestPlaywrightDebug: JestPlaywrightDebug
+      jestPlaywrightConfig: JestPlaywrightConfig
     }
   }
 }


### PR DESCRIPTION
Added ability to use `skip` and `only` for custom `jestPlaywright` functions:
```js
// Run specific test(s) only
test.jestPlaywrightDebug.only('test1', async () => {
  // ...
});

// Skip specific test(s)
test.jestPlaywrightConfig.skip({ /* ... */ }, 'test2', async () => {
  // ...
});
```

https://github.com/playwright-community/jest-playwright/issues/216#issuecomment-663236709