### PR TITLE
Add ability to config debugOptions with jest-playwright.config

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -100,6 +100,7 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
         exitOnPageError,
         selectors,
         launchType,
+        debugOptions,
       } = this._jestPlaywrightConfig
       if (wsEndpoint && !connectOptions?.wsEndpoint) {
         this._jestPlaywrightConfig.connectOptions = {
@@ -184,18 +185,24 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
           let resultBrowserConfig: JestPlaywrightConfig
           let resultContextOptions: BrowserContextOptions | undefined
           if (isDebug) {
-            resultBrowserConfig = config
-            resultContextOptions = config.contextOptions
+            resultBrowserConfig = debugOptions
+              ? deepMerge(config, debugOptions)
+              : config
+            resultContextOptions =
+              debugOptions && debugOptions.contextOptions
+                ? deepMerge(
+                    config.contextOptions!,
+                    debugOptions.contextOptions!,
+                  )
+                : config.contextOptions
           } else {
-            resultBrowserConfig = deepMerge(this._jestPlaywrightConfig, {
-              ...config,
-              launchType: LAUNCH,
-            })
+            resultBrowserConfig = deepMerge(this._jestPlaywrightConfig, config)
             resultContextOptions = {
               ...this._jestPlaywrightConfig.contextOptions,
               ...config.contextOptions,
             }
           }
+          resultBrowserConfig.launchType = LAUNCH
           const browser = await getBrowserPerProcess(
             playwrightInstance,
             browserType,

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -156,6 +156,7 @@ type Options<T> = T & Partial<Record<BrowserType, T>>
 export type ConnectOptions = Parameters<GenericBrowser['connect']>[0]
 
 export interface JestPlaywrightConfig {
+  debugOptions?: JestPlaywrightConfig
   launchType?: LaunchType
   launchOptions?: Options<LaunchOptions>
   connectOptions?: Options<ConnectOptions>


### PR DESCRIPTION
Added ability to support `debugOptions` in `jest-playwright.config`

```js
// jest-playwright.config.js
module.exports = {
  browsers: ['chromium', 'firefox', 'webkit'],
  debugOptions: {
    browsers: ['chromium'],
    launchOptions: {
      headless: false,
    },
  },
};
```

Extra information in #216 comments
