### PR TITLE
Add ability to pass config with jest config

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -18,6 +18,7 @@ import {
   IMPORT_KIND_PLAYWRIGHT,
   PERSISTENT,
   LAUNCH,
+  CONFIG_ENVIRONMENT_NAME,
 } from './constants'
 import {
   deepMerge,
@@ -25,7 +26,6 @@ import {
   getBrowserType,
   getDeviceType,
   getPlaywrightInstance,
-  readConfig,
 } from './utils'
 import { saveCoverageOnPage, saveCoverageToFile } from './coverage'
 
@@ -77,7 +77,6 @@ const getBrowserPerProcess = async (
 }
 
 export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const RootEnv = require(basicEnv === 'node'
     ? 'jest-environment-node'
     : 'jest-environment-jsdom')
@@ -92,8 +91,9 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
     }
 
     async setup(): Promise<void> {
-      const { rootDir, wsEndpoint, browserName } = this._config
-      this._jestPlaywrightConfig = await readConfig(rootDir)
+      const { wsEndpoint, browserName, testEnvironmentOptions } = this._config
+      this._jestPlaywrightConfig =
+        testEnvironmentOptions[CONFIG_ENVIRONMENT_NAME]
       const {
         connectOptions,
         collectCoverage,
@@ -102,7 +102,7 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
         launchType,
         debugOptions,
       } = this._jestPlaywrightConfig
-      if (wsEndpoint && !connectOptions?.wsEndpoint) {
+      if (wsEndpoint) {
         this._jestPlaywrightConfig.connectOptions = {
           ...connectOptions,
           wsEndpoint,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ import type { JestPlaywrightConfig, ConnectOptions } from '../types/global'
 
 export const IMPORT_KIND_PLAYWRIGHT = 'playwright'
 
+export const CONFIG_ENVIRONMENT_NAME = 'jest-playwright'
+
 export const CHROMIUM = 'chromium'
 export const FIREFOX = 'firefox'
 export const WEBKIT = 'webkit'

--- a/src/global.ts
+++ b/src/global.ts
@@ -26,9 +26,10 @@ const logMessage = ({
 export async function setup(
   jestConfig: JestConfig.GlobalConfig,
 ): Promise<void> {
+  // TODO It won't work if config doesn't exist in root directory or in jest.config.js file
   const config = await readConfig(jestConfig.rootDir)
 
-  // If we are in watch mode, - only setupServer() once.
+  // If we are in watch mode - only setupServer() once.
   if (jestConfig.watch || jestConfig.watchAll) {
     if (didAlreadyRunInWatchMode) return
     didAlreadyRunInWatchMode = true

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import * as Utils from './utils'
 import { DEFAULT_CONFIG, CHROMIUM, FIREFOX } from './constants'
-import type { BrowserType } from '../types/global'
+import type { BrowserType, JestPlaywrightConfig } from '../types/global'
 
 const {
   readConfig,
@@ -35,7 +35,7 @@ describe('readConfig', () => {
       launchOptions: {
         headless: true,
       },
-      browser: 'chromium',
+      browsers: ['chromium'],
       contextOptions: {
         viewport: {
           width: 800,
@@ -50,6 +50,29 @@ describe('readConfig', () => {
       { virtual: true },
     )
     const config = await readConfig()
+    expect(config).toMatchObject(configObject)
+  })
+  it('should overwrite config if the second param is passed', async () => {
+    const configObject = {
+      launchOptions: {
+        headless: true,
+      },
+      browsers: ['chromium'],
+    }
+    jest.mock(
+      path.join(__dirname, '..', 'jest-playwright.config.js'),
+      () => ({
+        launchOptions: {
+          headless: true,
+        },
+        browsers: ['webkit'],
+      }),
+      { virtual: true },
+    )
+    const config = await readConfig(
+      process.cwd(),
+      configObject as JestPlaywrightConfig,
+    )
     expect(config).toMatchObject(configObject)
   })
   it('should overwrite with a custom configuration and spread the "launchOptions" and "contextOptions" setting', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,7 +197,11 @@ export const getSkipFlag = (
 
 export const readConfig = async (
   rootDir: string = process.cwd(),
+  jestEnvConfig?: JestPlaywrightConfig,
 ): Promise<JestPlaywrightConfig> => {
+  if (jestEnvConfig) {
+    return deepMerge<JestPlaywrightConfig>(DEFAULT_CONFIG, jestEnvConfig)
+  }
   const hasCustomConfigPath = !!process.env.JEST_PLAYWRIGHT_CONFIG
   let fileExtension = 'js'
   if (process.env.npm_package_type === 'module') {


### PR DESCRIPTION
https://github.com/playwright-community/jest-playwright/issues/226#issuecomment-661825110

Added ability to pass config with **jest.config.js**:
```js
testEnvironmentOptions: {
        ...,
        'jest-playwright': {
            ...
        }
},
```

Also find out that there is problem with **globalSetup**, it will try to use config from root directory. IDK how we can use actual configuration, cause we got only **globalConfig** there