### PR TITLE
fix(firefox): remove isMobile in Firefox

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -149,6 +149,10 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
           contextOptions = { ...deviceProps, ...contextOptions }
         }
       }
+      if (browserType === 'firefox' && contextOptions.isMobile) {
+        console.warn('jest-playwright: isMobile is not supported in Firefox.')
+        delete contextOptions.isMobile
+      }
       this.global.browserName = browserType
       this.global.deviceName = deviceName
       const browserOrContext = await getBrowserPerProcess(


### PR DESCRIPTION
Fixes #337

In the Playwright-CLI we do it in the same way.