### PR TITLE
Extend Describe to include jestPlaywrightSkip

### DIFF
--- a/e2e/more.test.ts
+++ b/e2e/more.test.ts
@@ -14,4 +14,15 @@ describe('Example setContext test', () => {
       expect(element).toBeTruthy()
     },
   )
+  describe.jestPlaywrightSkip(
+    { browsers: ['chromium'] },
+    'can skip describe block',
+    () => {
+      it('should be able to execute javascript 1', async () => {
+        page.setContent(`<script>document.write("test")</script>`)
+        const element = await page.waitForSelector('text=test')
+        expect(element).toBeTruthy()
+      })
+    },
+  )
 })

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -130,6 +130,9 @@ declare global {
       jestPlaywrightDebug: JestPlaywrightTestDebug
       jestPlaywrightConfig: JestPlaywrightTestConfig
     }
+    interface Describe {
+      jestPlaywrightSkip: JestParams<SkipOption>
+    }
   }
 }
 


### PR DESCRIPTION
in https://github.com/playwright-community/jest-playwright/blob/master/src/extends.ts#L104 `describe` is extended with `jestPlaywrightSkip` but when I tried to use it typescript was complaining that it doesn't exist. 

This will add the type in just like the `it`.