### PR TITLE
fix connectOptions issue

### DIFF
--- a/src/PlaywrightRunner.ts
+++ b/src/PlaywrightRunner.ts
@@ -119,7 +119,7 @@ class PlaywrightRunner extends JestRunner {
     instance: GenericBrowser,
   ): Promise<WsEndpointType> {
     const { launchType, launchOptions, skipInitialization } = config
-    if (!skipInitialization || (launchType === SERVER && wsEndpoint === null)) {
+    if (!skipInitialization && launchType === SERVER && wsEndpoint === null) {
       if (!this.browser2Server[browser]) {
         const options = getBrowserOptions(browser, launchOptions)
         this.browser2Server[browser] = await instance.launchServer(options)
@@ -145,7 +145,7 @@ class PlaywrightRunner extends JestRunner {
             const browser = getBrowser(device, availableDevices)
             const wsEndpoint: WsEndpointType = await this.launchServer(
               config,
-              connectOptions?.wsEndpoint || null,
+              getBrowserOptions(browser, connectOptions)?.wsEndpoint || null,
               browser,
               (instance as Record<BrowserType, GenericBrowser>)[browser],
             )
@@ -166,7 +166,7 @@ class PlaywrightRunner extends JestRunner {
           const resultDevices = getDevices(devices, availableDevices)
           const wsEndpoint: WsEndpointType = await this.launchServer(
             config,
-            connectOptions?.wsEndpoint || null,
+            getBrowserOptions(browser, connectOptions)?.wsEndpoint || null,
             browser,
             instance as GenericBrowser,
           )


### PR DESCRIPTION
There are two issue.

1. always launches the server when skipInitialization is not defined even though we pass `launchType: SERVER` and  `wsEndpoint`.
https://github.com/playwright-community/jest-playwright/blob/06737bd4d311555f5d0fb2cdb87540e46b101e68/src/PlaywrightRunner.ts#L122
2. wsEndpoint can be defined in each client, but the logic is not applied it
https://github.com/playwright-community/jest-playwright/blob/06737bd4d311555f5d0fb2cdb87540e46b101e68/src/PlaywrightRunner.ts#L148

As a result, we couldn't use `wsEndpoint` to connect the existing browser.