### PR TITLE
Support chrome devtool connection

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -68,7 +68,9 @@ const getBrowserPerProcess = async (
   }
 
   const options = getBrowserOptions(browserType, connectOptions)
-  return options?.endpointURL ? playwrightInstance.connectOverCDP(options) : playwrightInstance.connect(options);
+  return options?.endpointURL
+    ? playwrightInstance.connectOverCDP(options)
+    : playwrightInstance.connect(options)
 }
 
 const getDeviceConfig = (

--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -68,7 +68,7 @@ const getBrowserPerProcess = async (
   }
 
   const options = getBrowserOptions(browserType, connectOptions)
-  return playwrightInstance.connect(options)
+  return options?.endpointURL ? playwrightInstance.connectOverCDP(options) : playwrightInstance.connect(options);
 }
 
 const getDeviceConfig = (

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -192,7 +192,9 @@ type LaunchType = typeof LAUNCH | typeof SERVER | typeof PERSISTENT
 
 type Options<T> = T & Partial<Record<BrowserType, T>>
 
-export type ConnectOptions = Parameters<GenericBrowser['connect']>[0]
+export type ConnectOptions = Parameters<GenericBrowser['connect']>[0] & {
+  endpointURL?: string
+}
 
 export type ServerOptions = JestProcessManagerOptions & {
   teardown?: string


### PR DESCRIPTION
Hey,

I Run into the issue, that the chrome devtool connection (`connectOverCDP`) as defined in https://playwright.dev/docs/api/class-browsertype/#browsertypeconnectovercdpparams is not supported. This addition would allow such a support by checking for the `endpointURL` argument in options and selecting connect function accordingly.

I hope this helps improve the extension.

Great work ❤️ 