### PR TITLE
Fix jest-environment-node peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       "peerDependencies": {
         "jest": ">=26.6.3",
         "jest-circus": ">=26.6.3",
-        "jest-environment-node": ">=26.6.3",
+        "jest-environment-node": ">=26.6.2",
         "jest-runner": ">=26.6.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "peerDependencies": {
     "jest": ">=26.6.3",
     "jest-circus": ">=26.6.3",
-    "jest-environment-node": ">=26.6.3",
+    "jest-environment-node": ">=26.6.2",
     "jest-runner": ">=26.6.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The current jest-environment-node peer dep is referencing a non-existant version.