### PR TITLE
Add ability to reset context per test

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ module.exports = {
 - `serverOptions` <[object]>. [All `jest-process-manager` options](https://github.com/playwright-community/jest-process-manager#options).
 - `selectors` <[array]>. Define [selectors](https://playwright.dev/docs/api/class-selectors/). Each selector must be an object with name and script properties.
 - `skipInitialization` <[boolean]>. Add you ability to skip first setup `playwright` process. Possible use cases can be found [here](https://github.com/playwright-community/jest-playwright/issues/424)
+- `resetContextPerTest` <[boolean]>. Option for opening a new context per test
 - `useDefaultBrowserType` <[boolean]>. [Sometimes](https://github.com/microsoft/playwright/issues/2787) `browser` + `device` combinations don't have any sense. With this option tests will be run with [`defaultBrowserType`](https://github.com/microsoft/playwright/pull/3731) of device. Pay attention that you should define **devices** to correct usage of this option.
 
 ### Usage of process environment to define browser

--- a/src/extends.ts
+++ b/src/extends.ts
@@ -1,8 +1,14 @@
 /* global jestPlaywright, browserName, deviceName */
 /* eslint-disable @typescript-eslint/no-explicit-any*/
 import { getSkipFlag, deepMerge } from './utils'
-import { SkipOption, TestPlaywrightConfigOptions } from '../types/global'
+import {
+  JestPlaywrightGlobal,
+  SkipOption,
+  TestPlaywrightConfigOptions,
+} from '../types/global'
 import { CONFIG_ENVIRONMENT_NAME, DEBUG_TIMEOUT } from './constants'
+
+declare const global: JestPlaywrightGlobal
 
 type TestType = 'it' | 'describe'
 
@@ -59,7 +65,7 @@ const runConfigTest = (
   const timer =
     typeof lastArg === 'number'
       ? lastArg
-      : (global as any)[CONFIG_ENVIRONMENT_NAME].testTimeout
+      : global[CONFIG_ENVIRONMENT_NAME].testTimeout
   jestTypeTest(
     args[0],
     async () => {
@@ -106,3 +112,9 @@ it.jestPlaywrightSkip = (skipOption, ...args) => {
 describe.jestPlaywrightSkip = (skipOption: SkipOption, ...args) => {
   customSkip(skipOption, 'describe', ...args)
 }
+
+beforeEach(async () => {
+  if (global[CONFIG_ENVIRONMENT_NAME].resetContextPerTest) {
+    await jestPlaywright.resetContext()
+  }
+})

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -20,6 +20,8 @@ import { JestProcessManagerOptions } from 'jest-process-manager'
 // TODO Find out flex ways to reuse constants
 declare const IMPORT_KIND_PLAYWRIGHT = 'playwright'
 
+declare const CONFIG_ENVIRONMENT_NAME = 'jest-playwright'
+
 declare const CHROMIUM = 'chromium'
 declare const FIREFOX = 'firefox'
 declare const WEBKIT = 'webkit'
@@ -39,6 +41,10 @@ export type BrowserType = typeof CHROMIUM | typeof FIREFOX | typeof WEBKIT
 export type SkipOption = {
   browsers: BrowserType[]
   devices?: string[] | RegExp
+}
+
+export interface JestPlaywrightGlobal extends NodeJS.Global {
+  [CONFIG_ENVIRONMENT_NAME]: JestPlaywrightConfig
 }
 
 export interface TestPlaywrightConfigOptions extends JestPlaywrightConfig {
@@ -200,6 +206,8 @@ export type ServerOptions = JestProcessManagerOptions & {
 export interface JestPlaywrightConfig {
   haveSkippedTests?: boolean
   skipInitialization?: boolean
+  resetContextPerTest?: boolean
+  testTimeout?: number
   debugOptions?: JestPlaywrightConfig
   launchType?: LaunchType
   launchOptions?: Options<LaunchOptions>


### PR DESCRIPTION
close #660 

will be controlled by `resetContextPerTest` in config. (**false** as default for a now)