### PR TITLE
Lock jest peer dependency to version 26 or 27

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,10 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "jest": ">=26.6.3",
-    "jest-circus": ">=26.6.3",
-    "jest-environment-node": ">=26.6.2",
-    "jest-runner": ">=26.6.3"
+    "jest": "^26.6.3 || ^27.0.0",
+    "jest-circus": "^26.6.3 || ^27.0.0",
+    "jest-environment-node": "^26.6.2 || ^27.0.0",
+    "jest-runner": "^26.6.3 || ^27.0.0"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",


### PR DESCRIPTION
Fixes #793

The package is not yet compatible with jest 28 and will currently break after `npm update`, if the user has not accidentally locked down a specific jest version themselves with:

> TypeError: Jest: Got error running globalSetup - /home/bodo/my-project/node_modules/@storybook/test-runner/playwright/global-setup.js, reason: Class extends value #<Object> is not a constructor or null


