### PR TITLE
Not chromium: skip font-render-hinting option

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -54,7 +54,7 @@ const getBrowserPerProcess = async (
     // https://github.com/mmarkelov/jest-playwright/issues/42#issuecomment-589170220
     if (browserType !== CHROMIUM && launchOptions?.args) {
       launchOptions.args = launchOptions.args.filter(
-        (item: string) => item !== '--no-sandbox',
+        (item: string) => item !== '--no-sandbox' && !item.startsWith("--font-render-hinting="),
       )
     }
 


### PR DESCRIPTION
Like with no-sandbox, webkit will not run with the flag --font-render-hinting. Specifically on Ubuntu 20 (github actions), it does fine on MacOS.

```
[TEST] Error: Browser closed.
[TEST] ==================== Browser output: ====================
[TEST] <launching> /home/runner/.cache/ms-playwright/webkit-1609/pw_run.sh --inspector-pipe --headless --no-startup-window --font-render-hinting=none
[TEST] <launched> pid=[57](https://github.com/releasehub-com/spacedust/runs/7297424381?check_suite_focus=true#step:5:58)65
[TEST] [pid=5765][err] Cannot parse arguments: Unknown option --font-render-hinting=none
[TEST]     at /home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/server/webkit/wkConnection.js:163:16
[TEST]     at new Promise (<anonymous>)
[TEST]     at WKSession.send (/home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/server/webkit/wkConnection.js:1[59](https://github.com/releasehub-com/spacedust/runs/7297424381?check_suite_focus=true#step:5:60):12)
[TEST]     at Function.connect (/home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/server/webkit/wkBrowser.js:51:47)
[TEST]     at WebKit._connectToTransport (/home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/server/webkit/webkit.js:40:33)
[TEST]     at WebKit._innerLaunch (/home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/server/browserType.js:146:32)
[TEST]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[TEST]     at async ProgressController.run (/home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/server/progress.js:101:22)
[TEST]     at async WebKit.launch (/home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/server/browserType.js:79:21)
[TEST]     at async BrowserServerLauncherImpl.launchServer (/home/runner/work/spacedust/spacedust/app/node_modules/playwright-core/lib/browserServerImpl.js:[60](https://github.com/releasehub-com/spacedust/runs/7297424381?check_suite_focus=true#step:5:61):21)
[TEST]     at async PlaywrightRunner.launchServer (/home/runner/work/spacedust/spacedust/app/node_modules/jest-playwright-preset/lib/PlaywrightRunner.js:[69](https://github.com/releasehub-com/spacedust/runs/7297424381?check_suite_focus=true#step:5:70):44)
[TEST]     at async PlaywrightRunner.getTests (/home/runner/work/spacedust/spacedust/app/node_modules/jest-playwright-preset/lib/PlaywrightRunner.js:90:36)
[TEST]     at async PlaywrightRunner.runTests (/home/runner/work/spacedust/spacedust/app/node_modules/jest-playwright-preset/lib/PlaywrightRunner.js:124:30)
[TEST]     at async TestScheduler.scheduleTests (/home/runner/work/spacedust/spacedust/app/node_modules/@jest/core/build/TestScheduler.js:333:13)
[TEST]     at async runJest (/home/runner/work/spacedust/spacedust/app/node_modules/@jest/core/build/runJest.js:404:19)
[TEST]     at async _run10000 (/home/runner/work/spacedust/spacedust/app/node_modules/@jest/core/build/cli/index.js:320:7)
```