### PR TITLE
Fix jest-runner peerDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "jest": "^29.3.1",
         "jest-circus": "^29.3.1",
         "jest-environment-node": "^29.3.1",
-        "jest-runner": "^29.3.10"
+        "jest-runner": "^29.3.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jest": "^29.3.1",
     "jest-circus": "^29.3.1",
     "jest-environment-node": "^29.3.1",
-    "jest-runner": "^29.3.10"
+    "jest-runner": "^29.3.1"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",


### PR DESCRIPTION
Found that a typo had sneeked into the peerDeps.

jest-runner should be at ^29.3.1 like all the other jest peerDeps and not ^29.3.**10**