### PR TITLE
Pass `context` to `PlaywrightEnvironment`'s parent (`RootEnv`) 

### DIFF
--- a/src/PlaywrightEnvironment.ts
+++ b/src/PlaywrightEnvironment.ts
@@ -8,7 +8,10 @@ import type {
   Page,
 } from 'playwright-core'
 import { Event } from 'jest-circus'
-import type { JestEnvironmentConfig } from '@jest/environment'
+import type {
+  JestEnvironmentConfig,
+  EnvironmentContext,
+} from '@jest/environment'
 import type {
   BrowserType,
   ConfigDeviceType,
@@ -115,8 +118,8 @@ export const getPlaywrightEnv = (basicEnv = 'node'): unknown => {
     readonly _config: JestPlaywrightProjectConfig
     _jestPlaywrightConfig!: JestPlaywrightConfig
 
-    constructor(config: JestEnvironmentConfig) {
-      super(config)
+    constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+      super(config, context)
       this._config = config.projectConfig as JestPlaywrightProjectConfig
     }
 


### PR DESCRIPTION
Fixes #819 

This is how jest recommends creating your own test environment ([jest docs](https://jestjs.io/docs/29.6/configuration#testenvironment-string)): 

```javascript
// my-custom-environment
const NodeEnvironment = require('jest-environment-node').TestEnvironment;

class CustomEnvironment extends NodeEnvironment {
  constructor(config, context) {
    super(config, context); // see context here
    console.log(config.globalConfig);
    console.log(config.projectConfig);
    this.testPath = context.testPath;
    this.docblockPragmas = context.docblockPragmas;
  }
```
